### PR TITLE
Make enum usage consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ $ npm run [script]
 - All output files are generated at `nodemaker/output` dir.
 - Generated files may contain `// TODO:` lines, for adding in custom logic.
 - `nodegen` prompts for node generation type. In **simple node generation**, the output node has its resources in a single file. In **complex node generation**, the output node has its resources in separate `*Description.ts` files.
-- `nodegen` generates no credential file if `metaParameters.auth` is an empty string.
+- `nodegen` generates no credential file if `metaParameters.authType` is `"None"`.
 - `packgen` retrieves the `package.json` at runtime from the official repo.
 
 ### Pre-requisites

--- a/_templates/gen/generateGenericFunctions/GenericFunctions.ejs.gen
+++ b/_templates/gen/generateGenericFunctions/GenericFunctions.ejs.gen
@@ -53,10 +53,9 @@ export async function <%= h.camelify(metaParameters.serviceName) %>ApiRequest(
 	};
 
 	try {
-		<%_ if (metaParameters.auth === "") { _%>
-		<%_ } else { _%>
+		<%_ if (metaParameters.authType !== "None") { _%>
 
-		const credentials = this.getCredentials('<%= h.getCredentialsString(h.camelify(metaParameters.serviceName), metaParameters.auth) %>');
+		const credentials = this.getCredentials('<%= h.getCredentialsString(h.camelify(metaParameters.serviceName), metaParameters.authType) %>');
 
 		if (credentials === undefined) {
 			throw new Error('No credentials got returned!');
@@ -71,7 +70,7 @@ export async function <%= h.camelify(metaParameters.serviceName) %>ApiRequest(
 			delete options.body;
 		}
 
-		<%_ if (metaParameters.auth === "OAuth2") { _%>
+		<%_ if (metaParameters.authType === "OAuth2") { _%>
 		return await this.helpers.requestOAuth2.call(this, '<%= h.getCredentialsString(h.camelify(metaParameters.serviceName), metaParameters.auth) %>', options);
 		<%_ } else { _%>
 		return await this.helpers.request!(options);
@@ -81,7 +80,7 @@ export async function <%= h.camelify(metaParameters.serviceName) %>ApiRequest(
 
 		// TODO: Replace TODO_ERROR_STATUS_CODE and TODO_ERROR_MESSAGE based on the error object returned by API.
 
-		<%_ if (metaParameters.auth !== "") { _%>
+		<%_ if (metaParameters.authType !== "None") { _%>
 		if (TODO_ERROR_STATUS_CODE === 401) {
 			// Return a clear error
 			throw new Error('The <%= metaParameters.serviceName %> credentials are invalid!');

--- a/_templates/gen/generateNodeCredentialDocs/NodeCredentialDocs.ejs.gen
+++ b/_templates/gen/generateNodeCredentialDocs/NodeCredentialDocs.ejs.gen
@@ -20,12 +20,12 @@ You can find information about the operations supported by the <%= docsParameter
 
 Create a [<%= name %>](<%= docsParameters.serviceUrl %>) account.
 
-<%_ if (metaParameters.auth === "Key") { _%>
+<%_ if (metaParameters.authType === "API Key") { _%>
 
 ## Using Access Token
 
 <!-- // TODO: Write steps for access token. -->
-<%_ } else if (metaParameters.auth === "OAuth2") { _%>
+<%_ } else if (metaParameters.authType === "OAuth2") { _%>
 ## Using OAuth
 
 <!-- // TODO: Write steps for OAuth. -->

--- a/generators/Generator.ts
+++ b/generators/Generator.ts
@@ -16,7 +16,9 @@ export default class Generator {
   deriveServiceCredentialName() {
     const serviceName = metaParameters.serviceName.replace(/\s/g, "");
     return (
-      serviceName + (metaParameters.auth === "OAuth2" ? "OAuth2" : "") + "Api"
+      serviceName +
+      (metaParameters.authType === "OAuth2" ? "OAuth2" : "") +
+      "Api"
     );
   }
 }

--- a/generators/NodeFilesGenerator.ts
+++ b/generators/NodeFilesGenerator.ts
@@ -34,7 +34,7 @@ export default class NodeFilesGenerator extends Generator {
   /**Generate `*.credentials.ts`.*/
   generateOAuth2CredentialsFile() {
     const command = this.formatCommand(`
-    gen generate${metaParameters.auth}Credential
+    gen generate${metaParameters.authType}Credential
       --name \"${metaParameters.serviceName}\"
       --serviceCredential ${this.deriveServiceCredentialName()}
     `);

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -17,12 +17,12 @@ declare namespace NodeJS {
 
 type MetaParameters = {
   serviceName: string;
-  auth: Auth;
+  authType: AuthType;
   nodeColor: string;
   apiUrl: string;
 };
 
-type Auth = "OAuth2" | "Key" | "";
+type AuthType = "OAuth2" | "API Key" | "None";
 
 // ----------------------------------
 //         Docs parameters

--- a/parameters.ts
+++ b/parameters.ts
@@ -1,6 +1,6 @@
 export const metaParameters: MetaParameters = {
   serviceName: "Hacker News",
-  auth: "OAuth2",
+  authType: "OAuth2",
   nodeColor: "#ff6600",
   apiUrl: "http://hn.algolia.com/api/v1/",
 };

--- a/scripts/generateNodeDocs.ts
+++ b/scripts/generateNodeDocs.ts
@@ -5,6 +5,6 @@ const docsGenerator = new NodeDocsGenerator();
 
 docsGenerator.generateNodeMainDocs();
 
-if (metaParameters.auth !== "") {
+if (metaParameters.authType !== "None") {
   docsGenerator.generateNodeCredentialDocs();
 }

--- a/scripts/generateNodeFiles.ts
+++ b/scripts/generateNodeFiles.ts
@@ -1,8 +1,7 @@
 import { metaParameters } from "../parameters";
 import NodeFilesGenerator from "../generators/NodeFilesGenerator";
 import Prompter from "../utils/Prompter";
-
-// In the context of "generateNodeFiles", "files" means functionality-related node files, i.e. "*.node.ts", "*.credentials.ts" and node resource description files (if appropriate), as opposed to docs files and the package.json file.
+import { NodeGenerationType, AuthType } from "../utils/enums";
 
 (async () => {
   const { nodeGenerationType } = await Prompter.forNodeGeneration();
@@ -12,11 +11,11 @@ import Prompter from "../utils/Prompter";
   generator.generateMainNodeFile(nodeGenerationType);
   generator.generateGenericFunctionsFile();
 
-  if (nodeGenerationType === "complex") {
+  if (nodeGenerationType === NodeGenerationType.Complex) {
     generator.generateResourceDescriptionFile();
   }
 
-  if (metaParameters.auth === "OAuth2") {
+  if (metaParameters.authType === AuthType.OAuth2) {
     generator.generateOAuth2CredentialsFile();
   }
 })();

--- a/utils/enums.ts
+++ b/utils/enums.ts
@@ -1,4 +1,25 @@
 /**
+ * Node generation may be:
+ * - Simple: Output node with resource operations and fields in a single file.
+ * - Complex: Output node with resource operations and fields in separate files.
+ */
+export enum NodeGenerationType {
+  Simple = "simple",
+  Complex = "complex",
+}
+
+/**The API auth type may be:
+ * - OAuth2: Various OAuth2 parameters required.
+ * - Api Key: Usually a token string credential.
+ * - None: No credential needed.
+ */
+export enum AuthType {
+  OAuth2 = "OAuth2",
+  ApiKey = "API Key",
+  None = "None",
+}
+
+/**
  * A node documentation file may be:
  * - Main: The node functionality documentation file to be placed at docs/nodes/nodes-library/nodes at the n8n-docs repo.
  * - Credentials: The node credentials documentation file to be placed at docs/nodes/credentials at the n8n-docs repo.
@@ -6,14 +27,4 @@
 export enum NodeDocFile {
   main,
   credential,
-}
-
-/**
- * Node generation may be:
- * - Simple: Output node with resource operations and fields in a single file.
- * - Complex: Output node with resource operations and fields in separate files.
- */
-export enum NodeGenerationType {
-  simple,
-  complex,
 }


### PR DESCRIPTION
This makes enum usage consistent for `NodeGenerationType` and `AuthType` (also renaming the latter), so that the output captured by `Prompter` can be compared to enums instead of strings.

This closes #4.