### PR TITLE
Validation as CLI utility

### DIFF
--- a/.hygen.js
+++ b/.hygen.js
@@ -1,6 +1,6 @@
 module.exports = {
   helpers: {
-    /**Check if a field or option is collective (containing fields or options).*/
+    /**Check if a field or option is collective (contains fields or options).*/
     isCollective: (entity) =>
       entity.type === "collection" ||
       entity.type === "fixedCollection" ||
@@ -8,8 +8,7 @@ module.exports = {
       entity.type === "options",
     /**Format a string as a class name, uppercase for each initial and no whitespace.*/
     classify: (name) => name.replace(/\s/g, ""),
-    /**Format a string as a lowercase single word, or a lowercase first word
-     * and uppercase initial + lowercase rest for following words.*/
+    /**Format a string as a lowercase single word, or a lowercase first word and uppercase initial + lowercase rest for following words.*/
     camelify: (input) => {
       const isSingleWord = input.split(" ").length === 1;
       const uppercaseInitialLowercaseRest = (input) =>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1455,6 +1455,11 @@
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
       "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
     },
+    "nested-error-stacks": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
+      "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug=="
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -1822,6 +1827,12 @@
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
       }
+    },
+    "reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
+      "optional": true
     },
     "require-directory": {
       "version": "2.1.1",
@@ -2359,6 +2370,23 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
       "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
     },
+    "tsutils": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+      "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+      "requires": {
+        "tslib": "^1.8.1"
+      }
+    },
+    "ttypescript": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.10.tgz",
+      "integrity": "sha512-Hk7TRej1hM+p+Fo+Pyb/XK9pe9CAt3Sh5n5YRutxFS8hUgkh2u1Vd2K40kMcNP3WYhiVFBMqXwM/2E8O95Ep6g==",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.9.0"
+      }
+    },
     "tunnel": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
@@ -2388,6 +2416,16 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz",
       "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==",
       "dev": true
+    },
+    "typescript-is": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/typescript-is/-/typescript-is-0.16.3.tgz",
+      "integrity": "sha512-Vlpo9YFnjWEBUyfD5Yx3MLYupxMdK15ZBHkDYOWpRZWcjXS2XNScKMWhY5JSouu9+q4wduGz/v1lfZdW9Hk+qQ==",
+      "requires": {
+        "nested-error-stacks": "^2",
+        "reflect-metadata": ">=0.1.12",
+        "tsutils": "^3.17.1"
+      }
     },
     "unbzip2-stream": {
       "version": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "runapp": "cd ../n8n && npm run start",
     "shotgen": "tsc && node build/scripts/takeScreenshot.js",
     "empty": "rm -rfv output/*",
-    "desktop": "cd client && npm run electron:serve"
+    "desktop": "cd client && npm run electron:serve",
+    "validate": "ttsc && node build/scripts/validateParams.js"
   },
   "keywords": [
     "n8n"
@@ -32,7 +33,8 @@
     "inquirer": "^7.3.1",
     "node-fetch": "^2.6.0",
     "puppeteer": "^5.2.1",
-    "sharp": "^0.25.4"
+    "sharp": "^0.25.4",
+    "typescript-is": "^0.16.3"
   },
   "devDependencies": {
     "@types/inquirer": "^6.5.0",
@@ -40,6 +42,7 @@
     "@types/node-fetch": "^2.5.7",
     "@types/puppeteer": "^3.0.1",
     "tsc-watch": "^4.2.9",
+    "ttypescript": "^1.5.10",
     "typescript": "^3.9.6"
   }
 }

--- a/scripts/validateParams.ts
+++ b/scripts/validateParams.ts
@@ -1,0 +1,12 @@
+import Validator from "../services/Validator";
+
+const dataToValidate = {
+  serviceName: "Hacker News",
+  authType: "OAuth2",
+  nodeColor: "#ff6600",
+  apiUrl: "http://hn.algolia.com/api/v1/",
+};
+
+const validator = new Validator();
+
+validator.validateDocsParameters(dataToValidate);

--- a/services/Validator.ts
+++ b/services/Validator.ts
@@ -1,0 +1,48 @@
+import { assertType } from "typescript-is";
+
+/**Responsible for validating an unknown object against a type and reporting missing properties or unexpected property types. Intended for troubleshooting why an object built on the frontend is failing to generate a node.*/
+export default class Validator {
+  private handleValidation(
+    callback: () => void,
+    hideStack = true,
+    hideInput = true,
+    hideMessage = true
+  ) {
+    try {
+      callback();
+      console.log("Parameters validation succeeded!");
+    } catch (error) {
+      if (hideStack) delete error.stack;
+      if (hideInput) delete error.input;
+      if (hideMessage) delete error.message;
+      console.error(error);
+    }
+  }
+
+  // TODO - De-duplicate these methods by abstracting away the type.
+  // Beware: https://github.com/woutervh-/typescript-is/issues/32
+  // Beware: https://github.com/woutervh-/typescript-is/blob/master/README.md#-what-it-wont-do
+  // validate<T>(params: any) {
+  //   this.handleValidation(() => assertType<T>(params));
+  // }
+
+  public validateMetaParameters(metaParameters: any) {
+    this.handleValidation(() => assertType<MetaParameters>(metaParameters));
+  }
+
+  public validateRegularNodeParameters(regularNodeParameters: any) {
+    this.handleValidation(() =>
+      assertType<RegularNodeParameters>(regularNodeParameters)
+    );
+  }
+
+  public validateTriggerNodeParameters(triggerNodeParameters: any) {
+    this.handleValidation(() =>
+      assertType<TriggerNodeParameters>(triggerNodeParameters)
+    );
+  }
+
+  public validateDocsParameters(docsParameters: any) {
+    this.handleValidation(() => assertType<DocsParameters>(docsParameters));
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,9 @@
 		"strict": true,
 		"strictPropertyInitialization": false,
 		"esModuleInterop": true,
-		"forceConsistentCasingInFileNames": true
+		"forceConsistentCasingInFileNames": true,
+		"plugins": [
+			{ "transform": "typescript-is/lib/transform-inline/transformer" }
+		]
 	}
 }


### PR DESCRIPTION
For the reasons [discussed on the relevant issue](https://github.com/MLH-Fellowship/nodemaker/issues/53#issuecomment-670508684), the validation channel should be recreated as a CLI utility to help troubleshoot why a certain parameter bundle built on the frontend is failing to generate a node.

This PR adds the command `npm run validate` to validate objects of type `any` against the types `MetaParameters`, `RegularNodeParameters`, `TriggerNodeParameters`, and `DocsParameters`. If the type guard validation fails, a message is returned with the reason, either a missing property or a wrong property type.

To validate the object, open `validateParams.ts`, assign the object to `dataToValidate`, and select the appropriate method: `validateMetaParameters`, `validateRegularNodeParameters`, `validateTriggerNodeParameters`, and `validateDocsParameters`.

```ts
import Validator from "../services/Validator";

const dataToValidate = {
  serviceName: "Hacker News",
  authType: "OAuth2",
  nodeColor: "#ff6600",
  apiUrl: "http://hn.algolia.com/api/v1/",
};

const validator = new Validator();

validator.validateMetaParameters(dataToValidate);
```

This is a prototype to be developed further in the future.

This closes #53.