### PR TITLE
Channel for emptying output directory

### DIFF
--- a/client/channels/EmptyChannel.ts
+++ b/client/channels/EmptyChannel.ts
@@ -1,16 +1,16 @@
 import { IpcMainEvent } from "electron";
 import IpcChannel from "./IpcChannel.interface";
-// import PackageJsonGenerator from "../../generators/PackageJsonGenerator";
+import DirectoryEmptier from "../../services/DirectoryEmptier";
 
 export default class EmptyChannel implements IpcChannel {
   public name = "empty-channel";
 
   public async handle(event: IpcMainEvent) {
     process.chdir("..");
-    // const generator = new PackageJsonGenerator(metaParameters);
-    // const result = await generator.run();
+    const emptier = new DirectoryEmptier();
+    const result = await emptier.run();
     process.chdir("client");
 
-    // event.sender.send(this.name, result);
+    event.sender.send(this.name, result);
   }
 }

--- a/client/channels/EmptyChannel.ts
+++ b/client/channels/EmptyChannel.ts
@@ -1,0 +1,16 @@
+import { IpcMainEvent } from "electron";
+import IpcChannel from "./IpcChannel.interface";
+// import PackageJsonGenerator from "../../generators/PackageJsonGenerator";
+
+export default class EmptyChannel implements IpcChannel {
+  public name = "empty-channel";
+
+  public async handle(event: IpcMainEvent) {
+    process.chdir("..");
+    // const generator = new PackageJsonGenerator(metaParameters);
+    // const result = await generator.run();
+    process.chdir("client");
+
+    // event.sender.send(this.name, result);
+  }
+}

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -21,7 +21,8 @@ type RequesterInputType =
   | NodegenParamsBundle
   | DocsgenParamsBundle
   | PlacementChannelArgument
-  | PackgenChannelArgument;
+  | PackgenChannelArgument
+  | EmptyChannelArgument;
 
 // prettier-ignore
 type RequesterOutputType<T> =
@@ -30,6 +31,7 @@ type RequesterOutputType<T> =
     T extends DocsgenParamsBundle ? BackendOperationResult :
     T extends PlacementChannelArgument ? BackendOperationResult :
     T extends PackgenChannelArgument ? BackendOperationResult :
+    T extends EmptyChannelArgument ? BackendOperationResult :
     never;
 
 type BackendOperationResult = SuccessfulOperationResult | FailedOperationResult;
@@ -47,6 +49,8 @@ type PlacementChannelArgument = {
 };
 
 type PackgenChannelArgument = MetaParameters;
+
+type EmptyChannelArgument = void;
 
 // ********************************************************************
 //                         Bundle-related

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "runapp-shotgen": "concurrently --kill-others-on-fail \"npm run runapp\" \"npm run shotgen\"",
     "runapp": "cd ../n8n && npm run start",
     "shotgen": "tsc && node build/scripts/takeScreenshot.js",
-    "empty": "rm -rfv output/*",
+    "empty": "tsc && node build/scripts/emptyOutputDir.js",
     "desktop": "cd client && npm run electron:serve",
     "validate": "ttsc && node build/scripts/validateParams.js"
   },

--- a/scripts/emptyOutputDir.ts
+++ b/scripts/emptyOutputDir.ts
@@ -1,0 +1,7 @@
+import DirectoryEmptier from "../services/DirectoryEmptier";
+
+(async () => {
+  const emptier = new DirectoryEmptier();
+  const result = await emptier.run();
+  console.log(result);
+})();

--- a/services/DirectoryEmptier.ts
+++ b/services/DirectoryEmptier.ts
@@ -1,0 +1,36 @@
+import fs, { readdirSync } from "fs";
+import { join } from "path";
+import { promisify } from "util";
+import { allButGitKeepAndIconCandidatesDir } from "../utils/findFiles";
+
+const deleteFile = promisify(fs.unlink);
+const deleteDir = promisify(fs.rmdir);
+
+export default class DirectoryEmptier {
+  private outputDir = join(__dirname, "..", "..", "output");
+  private iconCandidatesDir = join(this.outputDir, "icon-candidates");
+
+  public async run(): Promise<BackendOperationResult> {
+    try {
+      await this.deleteIconCandidatesDir();
+      const files = this.getFilesToBeDeleted();
+      files.forEach((file) => deleteFile(join("output", file)));
+      return { completed: true, error: false };
+    } catch (thrownError) {
+      return { completed: false, error: true, errorMessage: thrownError };
+    }
+  }
+
+  private async deleteIconCandidatesDir() {
+    if (fs.existsSync(this.iconCandidatesDir)) {
+      await deleteDir(this.iconCandidatesDir, { recursive: true });
+    }
+  }
+
+  /**Returns all filenames in the /output dir except for `.gitkeep` and the /icon-candidates dir and its contents.*/
+  private getFilesToBeDeleted() {
+    return readdirSync(this.outputDir).filter(
+      allButGitKeepAndIconCandidatesDir
+    );
+  }
+}

--- a/utils/findFiles.ts
+++ b/utils/findFiles.ts
@@ -20,3 +20,6 @@ export const isFuncFileInTypeScript = (file: string) =>
   !file.endsWith(".credentials.ts") &&
   !file.endsWith(".md") &&
   !file.endsWith(".txt");
+
+export const allButGitKeepAndIconCandidatesDir = (file: string) =>
+  file !== ".gitkeep" && file !== "icon-candidates";


### PR DESCRIPTION
This PR adds a channel for deleting the files in the `/output` directory, except for `.gitkeep`.

To empty out the `/output` directory:

```ts
const requester = new Requester();
const emptyResult = await requester.request<EmptyChannelArgument>(
    "empty-channel" // no more params needed
);
```

Possible reponses:

```ts
{ completed: true, error: false } // files at `/output` successfully deleted
{ completed: false, error: true, errorMessage: thrownError } // deletion of files at `/output` failed
```

This closes #88.