### PR TITLE
Finish workflow submission

### DIFF
--- a/_templates/gen/generateNodeMainDocs/NodeMainDocs.ejs.gen
+++ b/_templates/gen/generateNodeMainDocs/NodeMainDocs.ejs.gen
@@ -31,7 +31,7 @@ You can find authentication information for this node [here](../../../credential
 
 ## Example Usage
 
-This workflow allows you to <%= docsParameters.exampleUsage %>. You can also find the [workflow](https://n8n.io/workflows/<%= docsParameters.workflowNumber %>) on this website. This example usage workflow would use the following two nodes.
+This workflow allows you to <%= docsParameters.exampleUsage %>. You can also find the [workflow](<%= docsParameters.workflowUrl %>) on this website. This example usage workflow would use the following two nodes.
 - [Start](../../core-nodes/Start/README.md)
 - [<%= docsParameters.serviceName %>]()
 

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -101,7 +101,7 @@ type DocsParameters = {
   serviceUrl: string;
   introDescription: string;
   exampleUsage: string;
-  workflowNumber: string;
+  workflowUrl: string;
 };
 
 // ----------------------------------

--- a/parameters.ts
+++ b/parameters.ts
@@ -1,3 +1,5 @@
+import { getWorkflowUrl } from "./utils/getWorkflowNumber";
+
 export const metaParameters: MetaParameters = {
   serviceName: "Hacker News",
   authType: "OAuth2",
@@ -141,7 +143,7 @@ export const docsParameters: DocsParameters = {
   introDescription:
     "a social news website focusing on computer science and entrepreneurship",
   exampleUsage: "get an article from Hacker News",
-  workflowNumber: "123",
+  workflowUrl: getWorkflowUrl(),
 };
 
 export const triggerNodeParameters: TriggerNodeParameters = {

--- a/services/ScreenshotTaker.ts
+++ b/services/ScreenshotTaker.ts
@@ -12,7 +12,7 @@ export default class ScreenshotTaker {
   private browser: puppeteer.Browser;
   private page: puppeteer.Page; // browser tab
   private pngSavePath = join("output", "workflow.png"); // in-app screenshot
-  private urlSavePath = join("output", "image-upload-url.txt"); // uploaded image URL
+  private imageUploadUrlSavePath = join("output", "image-upload-url.txt"); // uploaded image URL
 
   constructor(private metaParameters: MetaParameters) {}
 
@@ -76,7 +76,7 @@ export default class ScreenshotTaker {
 
   /**TODO - Temporary function to save image upload URL to a TXT file. To be adjusted once UI needs are clear.*/
   private saveUrlToDisk(url: string) {
-    writeFileSync(this.urlSavePath, url, "utf8");
+    writeFileSync(this.imageUploadUrlSavePath, url, "utf8");
   }
 
   private async getJsonNodeCode() {

--- a/utils/getWorkflowNumber.ts
+++ b/utils/getWorkflowNumber.ts
@@ -1,0 +1,7 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+/**Extracts the workflow number from `workflow-submission-url.txt`, for use in docsgen.*/
+export const getWorkflowUrl = () => {
+  return readFileSync(join("output", "workflow-submission-url.txt")).toString();
+};


### PR DESCRIPTION
This PR closes #85.

@erin2722 Be careful because this contains a type change in `DocsParameters` that should be reflected on the frontend:

```ts
type DocsParameters = {
  serviceName: string;
  serviceUrl: string;
  introDescription: string;
  exampleUsage: string;
  workflowUrl: string; // new property name!
};
```

Any string is acceptable. One idea would be to hardcode `"https://n8n.io/workflows/123"` on the frontend object, since implementing `flowgen` on the frontend will not be included in the MVP.