### PR TITLE
Add numerical limits to global types

### DIFF
--- a/.hygen.js
+++ b/.hygen.js
@@ -46,5 +46,6 @@ module.exports = {
         .replace(/\/\$\$/, "/${")
         .replace(/\$\$$/, "}")
         .replace(/\"/g, "`"),
+    hasNumericalLimits: (field) => field.numericalLimits,
   },
 };

--- a/_templates/gen/generateRegularNodeSimple/RegularNodeSimple.ejs.gen
+++ b/_templates/gen/generateRegularNodeSimple/RegularNodeSimple.ejs.gen
@@ -101,6 +101,12 @@ export class <%= h.classify(metaParameters.serviceName) %> implements INodeType 
 				description: '<%= field.description %>',
 				<%_ } _%>
 				type: '<%= field.type %>',
+				<%_ if (h.hasNumericalLimits(field)) { _%>
+				typeOptions: {
+					minValue: <%= field.numericalLimits.minLimit %>,
+					maxValue: <%= field.numericalLimits.maxLimit %>
+				},
+				<%_ } _%>
 				required: <%= field.name !== 'additionalFields' ? true : false %>,
 				default: <%_ if (field.default === true || field.default === false || typeof field.default === "number") { _%>
 				<%_ %> <%= field.default _%>,

--- a/_templates/gen/generateResourceDescription/ResourceDescription.ejs.gen
+++ b/_templates/gen/generateResourceDescription/ResourceDescription.ejs.gen
@@ -43,6 +43,12 @@ export const <%= h.camelify(resourceName) %>Fields = [
 		description: '<%= field.description %>',
 		<%_ } _%>
 		type: '<%= field.type %>',
+		<%_ if (h.hasNumericalLimits(field)) { _%>
+		typeOptions: {
+			minValue: <%= field.numericalLimits.minLimit %>,
+			maxValue: <%= field.numericalLimits.maxLimit %>
+		},
+		<%_ } _%>
 		required: <%= field.name !== 'additionalFields' ? true : false %>,
 		default: <%_ if (field.default === true || field.default === false || typeof field.default === "number") { _%>
 		<%_ %> <%= field.default _%>,

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -172,6 +172,7 @@ type SingleValueOperationField = {
   type: SingleValueFieldType;
   default: SingleValueFieldDefault;
   extraDisplayRestriction?: { [key: string]: boolean };
+  numericalLimits?: { minLimit: number; maxLimit: number }; // for `type: number` only
 };
 
 type ManyValuesGroupField = {


### PR DESCRIPTION
This PR is my work in progress to 
- [x] add an optional `numericalLimits` property for `number` in `SingleValueOperationField`
- [x] adjust the templates to use this property.

Example input params:
```ts
export const regularNodeParameters: RegularNodeParameters = {
  Resource: [
    {
      name: "GET",
      description: "Get a sample resource",
      endpoint: "/resource",
      requestMethod: "GET",
      fields: [
        {
          name: "Resource ID",
          description: "The ID of the resource",
          type: "number",
          default: 5,
          numericalLimits: { minLimit: 5, maxLimit: 10 },
        },
      ],
    },
  ],
};
```

Example field output:
```ts
{
  displayName: 'Resource ID',
  name: 'Resource ID',
  description: 'The ID of the resource',
  type: 'number',
  typeOptions: {
    minValue: 5,
    maxValue: 10
  },
  required: true,
  default: 0,
  displayOptions: {
    show: {
      resource: [
        'resource',
      ],
      operation: [
        'get',
      ],
    },
  },
}
```

Closes #61.