### PR TITLE
Add alphabetical sorting of options

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -207,3 +207,7 @@ type MaxNestedFieldOption = {
   name: string;
   description: string;
 };
+
+type OptionWithMaxNesting = ManyValuesGroupFieldOption & {
+  options: MaxNestedFieldOption[];
+}; // only used for type guard

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,6 +102,12 @@
         "@types/node": "*"
       }
     },
+    "@types/underscore": {
+      "version": "1.10.21",
+      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.10.21.tgz",
+      "integrity": "sha512-tDEGvuNq36TPjzqXwqzjbcRJSn0I7XH03817tWVhAaaz8k5+0CwUH2K2KpZ3oB5sgkhGMV2l6KhIG401I+ODgg==",
+      "dev": true
+    },
     "@types/yauzl": {
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
@@ -2369,6 +2375,11 @@
         "buffer": "^5.2.1",
         "through": "^2.3.8"
       }
+    },
+    "underscore": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
+      "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg=="
     },
     "universalify": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "node-fetch": "^2.6.0",
     "puppeteer": "^5.2.1",
     "sharp": "^0.25.4",
-    "typescript-is": "^0.16.3"
+    "typescript-is": "^0.16.3",
+    "underscore": "^1.10.2"
   },
   "devDependencies": {
     "@types/inquirer": "^6.5.0",
@@ -43,6 +44,7 @@
     "@types/node-fetch": "^2.5.7",
     "@types/puppeteer": "^3.0.1",
     "@types/sharp": "^0.25.1",
+    "@types/underscore": "^1.10.21",
     "ttypescript": "^1.5.10",
     "typescript": "^3.9.6"
   }

--- a/parameters.ts
+++ b/parameters.ts
@@ -62,7 +62,7 @@ export const regularNodeParameters: RegularNodeParameters = {
           default: {},
           options: [
             {
-              name: "Keyword",
+              name: "Tags",
               description: "The keyword for filtering the results of the query",
               type: "multiOptions",
               default: "",
@@ -78,7 +78,7 @@ export const regularNodeParameters: RegularNodeParameters = {
               ],
             },
             {
-              name: "Tags",
+              name: "Keyword",
               description: "Tags for filtering the results of the query",
               type: "multiOptions",
               default: {},

--- a/parameters.ts
+++ b/parameters.ts
@@ -64,8 +64,18 @@ export const regularNodeParameters: RegularNodeParameters = {
             {
               name: "Keyword",
               description: "The keyword for filtering the results of the query",
-              type: "string",
+              type: "multiOptions",
               default: "",
+              options: [
+                {
+                  name: "Feature1",
+                  description: "Some description",
+                },
+                {
+                  name: "Feature2",
+                  description: "Some other description",
+                },
+              ],
             },
             {
               name: "Tags",

--- a/scripts/generateNodeFiles.ts
+++ b/scripts/generateNodeFiles.ts
@@ -31,7 +31,7 @@ import Highlighter from "../services/Highlighter";
   };
 
   const generator = new NodeFilesGenerator(paramsBundle);
-  const result = await generator.run();
+  const result = await generator.run({ checkSorting: false });
 
   Highlighter.showResult({
     result,

--- a/scripts/generateNodeFiles.ts
+++ b/scripts/generateNodeFiles.ts
@@ -13,7 +13,7 @@ import Highlighter from "../services/Highlighter";
 
   let nodeGenerationType: NodeGenerationType;
 
-  // regular node may be simple or complex, trigger node is simple
+  // regular node may be simple or complex, trigger node is always simple
   nodeType === NodeTypeEnum.Regular
     ? ({ nodeGenerationType } = await Prompter.forNodeGenerationType())
     : (nodeGenerationType = "Simple");
@@ -31,7 +31,7 @@ import Highlighter from "../services/Highlighter";
   };
 
   const generator = new NodeFilesGenerator(paramsBundle);
-  const result = await generator.run({ checkSorting: false });
+  const result = await generator.run();
 
   Highlighter.showResult({
     result,

--- a/utils/typeGuards.ts
+++ b/utils/typeGuards.ts
@@ -2,3 +2,15 @@ export const areTriggerNodeParameters = (
   params: MainParameters
 ): params is TriggerNodeParameters =>
   (params as TriggerNodeParameters).webhookProperties !== undefined;
+
+export const isManyValuesGroupField = (
+  field: OperationField
+): field is ManyValuesGroupField =>
+  (field as ManyValuesGroupField).type === "options" ||
+  (field as ManyValuesGroupField).type === "multiOptions" ||
+  (field as ManyValuesGroupField).type === "collection" ||
+  (field as ManyValuesGroupField).type === "fixedCollection";
+
+export const isOptionWithMaxNesting = (
+  option: ManyValuesGroupFieldOption
+): option is OptionWithMaxNesting => option.options !== undefined;


### PR DESCRIPTION
This PR automatically sorts all the `options` (at the first and second/max level of nesting) of regular node params object, to close #65.